### PR TITLE
Few updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Documentation for Windows and Vs Code has been started.
 - A new example to demonstrate how to build and integrate the libc (picolibc).
-- Added LICENSE file
+- LICENSE file (MIT)
 - `c_optimization` to override `-O0` in debug mode in the `build.zig` script.  
-- Added `-Wextra` to C flags in the `build.zig` script.
+- `-Wextra` to C flags in the `build.zig` script.
+- `myPanic` function for each example
+- `arm-none-eabi-size` or `llvm-size` command to be executed after build.
+- Safe build task with Vscode
+- Description paragraph for each example
 
 ### Changed
 
@@ -24,10 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The organization of project examples has been changed. The project is now open to other platforms/targets.
 - `addCMacro` is used for defining macros instead of using C flags.
 - `callconv(.C)` to `callconv(.c)`
+- `zigEntrypoint` with `callconv(.c)` attribute
 
 ### Removed
 
 - CMake is no longer used. The objective of this repository is to stay focused on Zig project integration.
+- libc test Code in examples.
 
 ## [0.13.0] - 2024-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
- # Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- Documentation for Windows and Vs Code has been started.
+- A new example to demonstrate how to build and integrate the libc (picolibc).
+- Added LICENSE file
+- `c_optimization` to override `-O0` in debug mode in the `build.zig` script.  
+- Added `-Wextra` to C flags in the `build.zig` script.
+
+### Changed
+
+- This release updates examples to the most recent version of Zig. (0.14.0)
+- Update Softwares, Drivers and Tools
+- The container image has been improved (reduced image size, enhanced flash device support, and ELF debug capability).
+- The general documentation and examples documentation have been improved.
+- The organization of project examples has been changed. The project is now open to other platforms/targets.
+- `addCMacro` is used for defining macros instead of using C flags.
+- `callconv(.C)` to `callconv(.c)`
+
+### Removed
+
+- CMake is no longer used. The objective of this repository is to stay focused on Zig project integration.
+
+## [0.13.0] - 2024-06-11
+
+- Tag 0.13.0 build version
 
 ### Added
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,6 @@
 - [ ] Add CI to compile every example.
 - [ ] Add more examples code ()
 - [ ] Add more target (nrf52, raspberry pi pico)
-- [ ] Custom Panic function to implement for runtime error (using UART interface)
+- [X] Custom Panic function to implement for runtime error (using UART interface)
 - [ ] Add Testing unit using Zig
 - [ ] Update `.clang-format` to correspond to Zig style guide.

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,14 @@
 # TODO
 
-- [ ] Add a way to generate map file (equivalent to -Wl,-Map=<name>.map,--cref)
+- [X] ~~Add a way to generate map file (equivalent to -Wl,-Map=<name>.map,--cref)~~ Option not available with clang
 - [ ] Add a memory view if possible equivalent to (-Wl,--print-memory-usage)
 - [ ] Generate `compile_commands.json` with Zig
-- [ ] Improve libc Integration (when It is possible)
-- [ ] Create HAL and LL as separate Zig module
+- [ ] Improve libc Integration
+- [ ] Create HAL and LL drivers as separate Zig module
 - [ ] Improve FreeRTOS example with an interface abstraction to avoid problems with macros translation.
 - [ ] Add CI to compile every example.
 - [ ] Add more examples code ()
 - [ ] Add more target (nrf52, raspberry pi pico)
-- [ ] Custom Panic function to implement for runtime error
+- [ ] Custom Panic function to implement for runtime error (using UART interface)
+- [ ] Add Testing unit using Zig
+- [ ] Update `.clang-format` to correspond to Zig style guide.

--- a/projects/stm32l476_nucleo/blinky/.vscode/tasks.json
+++ b/projects/stm32l476_nucleo/blinky/.vscode/tasks.json
@@ -31,7 +31,7 @@
             }
         },
         {
-            "label": "$(gear) Build",
+            "label": "$(gear) Debug build",
             "type": "shell",
             "linux": {
                 "command": "zig build",
@@ -46,7 +46,33 @@
                 "cwd": "${workspaceRoot}",
                 "statusbar": {
                     "color": "#48c548",
-                    "label": "$(gear) Build"
+                    "label": "$(gear) Debug"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "$(gear) Safe build",
+            "type": "shell",
+            "linux": {
+                "command": "zig build --release=safe",
+            },
+            "osx": {
+                "command": "zig build --release=safe",
+            },
+            "windows": {
+                "command": "zig build --release=safe",
+            },
+            "options": {
+                "cwd": "${workspaceRoot}",
+                "statusbar": {
+                    "color": "#48c548",
+                    "label": "$(gear) Safe"
                 }
             },
             "isBackground": true,

--- a/projects/stm32l476_nucleo/blinky/Core/Src/main.c
+++ b/projects/stm32l476_nucleo/blinky/Core/Src/main.c
@@ -20,9 +20,7 @@
 #include "main.h"
 #include "usart.h"
 #include "gpio.h"
-#include <stdio.h>
-#include <math.h>
-#include <stdlib.h>
+
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 
@@ -68,17 +66,6 @@ int main(void)
 {
 
     /* USER CODE BEGIN 1 */
-    char test_libc[53];
-    volatile float a  = sinf(55);
-    volatile double b = sin(55);
-
-    // Formatting test
-    snprintf(test_libc, sizeof(test_libc),  "%f,%f", a, b);
-    //
-    const unsigned int malloc_size = 50;
-    char* malloc_test              = (char*)malloc(malloc_size);
-    snprintf(malloc_test, malloc_size, "ptr: %u, size:%d", malloc_size, (uintptr_t)malloc_test);
-    printf("%s", malloc_test);
 
     /* USER CODE END 1 */
 

--- a/projects/stm32l476_nucleo/blinky/README.md
+++ b/projects/stm32l476_nucleo/blinky/README.md
@@ -1,6 +1,11 @@
+## Description
+
+This is a simple blinky program written in Zig. It uses the **HAL** drivers, leveraging Zig's `@cImport` capability.
+The generated startup code is preserved, and we use Zig's build system for compilation.
+Our Zig code begins at `zigEntrypoint`, and this function is called from C code using linker capabilities. The function is tagged with `callconv(.C)` to ensure compatibility with the C ABI.
+
 ## Use Zig after generating the project with STM32CubeMX
 
-Details about project structure are explained in this [chapter](#Structure).
 To use Zig in any microcontrollers `STM32CubeMX` generated project, follow these modification steps:
 
 1. **Create a `build.zig` file** and configure it to compile the C source files (Use this one as a model).

--- a/projects/stm32l476_nucleo/blinky/build.zig
+++ b/projects/stm32l476_nucleo/blinky/build.zig
@@ -173,7 +173,7 @@ pub fn build(b: *std.Build) void {
         objsize.step.dependOn(&elf.step);
         b.default_step.dependOn(&objsize.step);
     } else {
-        std.log.warn("'size' program not found", .{});
+        std.log.warn("'llvm-size' or 'arm-none-eabi-size' program not found", .{});
     }
 
     // Copy the bin out of the elf

--- a/projects/stm32l476_nucleo/blinky/src/main.zig
+++ b/projects/stm32l476_nucleo/blinky/src/main.zig
@@ -4,6 +4,7 @@ const c = @cImport({
     @cDefine("STM32L476xx", {});
     @cDefine("__PROGRAM_START", {}); //bug: https://github.com/ziglang/zig/issues/22671
     @cInclude("main.h");
+    @cInclude("usart.h");
 });
 
 export fn zigEntrypoint() callconv(.c) noreturn {
@@ -13,4 +14,25 @@ export fn zigEntrypoint() callconv(.c) noreturn {
         c.HAL_GPIO_WritePin(c.LD2_GPIO_Port, c.LD2_Pin, c.GPIO_PIN_SET);
         c.HAL_Delay(500);
     }
+}
+
+// Custom debug Panic implementation that will be used to print on UART.
+pub const panic = std.debug.FullPanic(myPanic);
+
+fn myPanic(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    // `_disable_irq()` is demoted to extern but don't work. Maybe because it is was a "static inline" function. Need investigation
+    asm volatile ("cpsid i" ::: "memory");
+
+    //Start printing, ensure error is impossible or ignore it. We are already on an error state.
+    var buffer: [1024]u8 = undefined;
+    var size: u16 = 0;
+    var result = std.fmt.bufPrint(&buffer, "\n\n", .{}) catch unreachable;
+    if (first_trace_addr) |addr| {
+        result = std.fmt.bufPrint(buffer[result.len..], "0x{x} / ", .{addr}) catch unreachable;
+        size += @intCast(result.len);
+    }
+    result = std.fmt.bufPrint(buffer[result.len..], "Panic! {s}\n", .{msg}) catch unreachable;
+    size += @intCast(result.len);
+    _ = c.HAL_UART_Transmit(&c.huart2, buffer[0..], size, 2000);
+    while (true) {}
 }

--- a/projects/stm32l476_nucleo/blinky/src/main.zig
+++ b/projects/stm32l476_nucleo/blinky/src/main.zig
@@ -6,7 +6,7 @@ const c = @cImport({
     @cInclude("main.h");
 });
 
-export fn zigEntrypoint() noreturn {
+export fn zigEntrypoint() callconv(.c) noreturn {
     while (true) {
         c.HAL_GPIO_WritePin(c.LD2_GPIO_Port, c.LD2_Pin, c.GPIO_PIN_RESET);
         c.HAL_Delay(200);

--- a/projects/stm32l476_nucleo/blinky_freertos/.vscode/tasks.json
+++ b/projects/stm32l476_nucleo/blinky_freertos/.vscode/tasks.json
@@ -31,7 +31,7 @@
             }
         },
         {
-            "label": "$(gear) Build",
+            "label": "$(gear) Debug build",
             "type": "shell",
             "linux": {
                 "command": "zig build",
@@ -46,7 +46,33 @@
                 "cwd": "${workspaceRoot}",
                 "statusbar": {
                     "color": "#48c548",
-                    "label": "$(gear) Build"
+                    "label": "$(gear) Debug"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "$(gear) Safe build",
+            "type": "shell",
+            "linux": {
+                "command": "zig build --release=safe",
+            },
+            "osx": {
+                "command": "zig build --release=safe",
+            },
+            "windows": {
+                "command": "zig build --release=safe",
+            },
+            "options": {
+                "cwd": "${workspaceRoot}",
+                "statusbar": {
+                    "color": "#48c548",
+                    "label": "$(gear) Safe"
                 }
             },
             "isBackground": true,

--- a/projects/stm32l476_nucleo/blinky_freertos/README.md
+++ b/projects/stm32l476_nucleo/blinky_freertos/README.md
@@ -1,6 +1,11 @@
+## Description
+
+This has the same goal as the **blinky** example, but it is an experiment to implement it using a **FreeRTOS task**.  
+The FreeRTOS source was included in the compilation script. Using **libc** is now mandatory, and we rely on **newlib** provided by GCC (`elf.linkSystemLibrary("c_nano");`).  
+Our Zig code begins at `zigEntrypoint`, and this function is called from C code using linker capabilities. The function is tagged with `callconv(.C)` to ensure compatibility with the C ABI.
+
 ## Use Zig after generating the project with STM32CubeMX
 
-Details about project structure are explained in this [chapter](#Structure).
 To use Zig in any microcontrollers `STM32CubeMX` generated project, follow these modification steps:
 
 1. **Create a `build.zig` file** and configure it to compile the C source files (Use this one as a model).

--- a/projects/stm32l476_nucleo/blinky_freertos/build.zig
+++ b/projects/stm32l476_nucleo/blinky_freertos/build.zig
@@ -162,7 +162,7 @@ pub fn build(b: *std.Build) void {
 
     //Need libc
     os_mod.addSystemIncludePath(.{ .cwd_relative = b.fmt("{s}/include", .{gcc_arm_sysroot_path}) });
-    os_mod.linkSystemLibrary("c_nano", .{ .needed = true, .weak = false, .preferred_link_mode = .static });
+    //os_mod.linkSystemLibrary("c_nano", .{ .needed = true, .weak = false, .preferred_link_mode = .static });
     os_mod.addCMacro("USE_HAL_DRIVER", "");
     os_mod.addCMacro("STM32L476xx", "");
 

--- a/projects/stm32l476_nucleo/blinky_freertos/build.zig
+++ b/projects/stm32l476_nucleo/blinky_freertos/build.zig
@@ -215,7 +215,7 @@ pub fn build(b: *std.Build) void {
         objsize.step.dependOn(&elf.step);
         b.default_step.dependOn(&objsize.step);
     } else {
-        std.log.warn("'size' program not found", .{});
+        std.log.warn("'llvm-size' or 'arm-none-eabi-size' program not found", .{});
     }
 
     // Copy the bin out of the elf

--- a/projects/stm32l476_nucleo/blinky_freertos/build.zig
+++ b/projects/stm32l476_nucleo/blinky_freertos/build.zig
@@ -203,6 +203,21 @@ pub fn build(b: *std.Build) void {
     elf.forceUndefinedSymbol("uxTopUsedPriority");
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Show section sizes inside binary files
+    const size_prog: ?[]const u8 = b.findProgram(&.{"arm-none-eabi-size"}, &.{}) catch
+        b.findProgram(&.{"llvm-size"}, &.{}) catch null;
+    if (size_prog) |name| {
+        const objsize = b.addSystemCommand(&[_][]const u8{
+            name,
+            "zig-out/bin/" ++ executable_name ++ ".elf",
+        });
+        objsize.step.dependOn(&elf.step);
+        b.default_step.dependOn(&objsize.step);
+    } else {
+        std.log.warn("'size' program not found", .{});
+    }
+
     // Copy the bin out of the elf
     const bin = b.addObjCopy(elf.getEmittedBin(), .{
         .format = .bin,

--- a/projects/stm32l476_nucleo/blinky_freertos/src/main.zig
+++ b/projects/stm32l476_nucleo/blinky_freertos/src/main.zig
@@ -17,7 +17,7 @@ export fn zig_task(params: ?*anyopaque) callconv(.c) void {
 
     while (true) {
         c.HAL_GPIO_WritePin(c.LD2_GPIO_Port, c.LD2_Pin, c.GPIO_PIN_RESET);
-        os.vTaskDelay(200);
+        os.vTaskDelay(200); // It will delay 2s. Macro "pdMS_TO_TICKS" convert tick to ms don't work as expected.
         c.HAL_GPIO_WritePin(c.LD2_GPIO_Port, c.LD2_Pin, c.GPIO_PIN_SET);
         os.vTaskDelay(200);
     }

--- a/projects/stm32l476_nucleo/blinky_freertos/src/main.zig
+++ b/projects/stm32l476_nucleo/blinky_freertos/src/main.zig
@@ -4,6 +4,7 @@ const c = @cImport({
     @cDefine("STM32L476xx", {});
     @cDefine("__PROGRAM_START", {}); //bug: https://github.com/ziglang/zig/issues/22671
     @cInclude("main.h");
+    @cInclude("usart.h");
 });
 
 const os = @cImport({
@@ -32,4 +33,25 @@ export fn zigEntrypoint() callconv(.c) void {
     os.vTaskStartScheduler();
 
     unreachable;
+}
+
+// Custom debug Panic implementation that will be used to print on UART.
+pub const panic = std.debug.FullPanic(myPanic);
+
+fn myPanic(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    // `_disable_irq()` is demoted to extern but don't work. Maybe because it is was a "static inline" function. Need investigation
+    asm volatile ("cpsid i" ::: "memory");
+
+    //Start printing, ensure error is impossible or ignore it. We are already on an error state.
+    var buffer: [1024]u8 = undefined;
+    var size: u16 = 0;
+    var result = std.fmt.bufPrint(&buffer, "\n\n", .{}) catch unreachable;
+    if (first_trace_addr) |addr| {
+        result = std.fmt.bufPrint(buffer[result.len..], "0x{x} / ", .{addr}) catch unreachable;
+        size += @intCast(result.len);
+    }
+    result = std.fmt.bufPrint(buffer[result.len..], "Panic! {s}\n", .{msg}) catch unreachable;
+    size += @intCast(result.len);
+    _ = c.HAL_UART_Transmit(&c.huart2, buffer[0..], size, 2000);
+    while (true) {}
 }

--- a/projects/stm32l476_nucleo/blinky_freertos/src/main.zig
+++ b/projects/stm32l476_nucleo/blinky_freertos/src/main.zig
@@ -22,7 +22,7 @@ export fn zig_task(params: ?*anyopaque) callconv(.c) void {
     }
 }
 
-export fn zigEntrypoint() void {
+export fn zigEntrypoint() callconv(.c) void {
 
     // Temporary task to initialize the system
     const pvParameters: ?*anyopaque = null;

--- a/projects/stm32l476_nucleo/blinky_picolibc/.vscode/tasks.json
+++ b/projects/stm32l476_nucleo/blinky_picolibc/.vscode/tasks.json
@@ -31,7 +31,7 @@
             }
         },
         {
-            "label": "$(gear) Build",
+            "label": "$(gear) Debug build",
             "type": "shell",
             "linux": {
                 "command": "zig build",
@@ -46,7 +46,33 @@
                 "cwd": "${workspaceRoot}",
                 "statusbar": {
                     "color": "#48c548",
-                    "label": "$(gear) Build"
+                    "label": "$(gear) Debug"
+                }
+            },
+            "isBackground": true,
+            "problemMatcher": [],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "label": "$(gear) Safe build",
+            "type": "shell",
+            "linux": {
+                "command": "zig build --release=safe",
+            },
+            "osx": {
+                "command": "zig build --release=safe",
+            },
+            "windows": {
+                "command": "zig build --release=safe",
+            },
+            "options": {
+                "cwd": "${workspaceRoot}",
+                "statusbar": {
+                    "color": "#48c548",
+                    "label": "$(gear) safe"
                 }
             },
             "isBackground": true,

--- a/projects/stm32l476_nucleo/blinky_picolibc/Core/Src/main.c
+++ b/projects/stm32l476_nucleo/blinky_picolibc/Core/Src/main.c
@@ -23,11 +23,8 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
-#include <stdio.h>
-#include <math.h>
-#include <stdint.h>
 #include <string.h>
-#include <stdlib.h>
+
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -88,17 +85,6 @@ void _init(void)
 int main(void)
 {
     /* USER CODE BEGIN 1 */
-
-    // math test
-    volatile float a  = sinf(55);
-    volatile double b = sin(55);
-    // Formatting test
-    snprintf(memory2_area, sizeof(memory2_area), "%f,%f", a, b);
-    //
-    const unsigned int malloc_size = 50;
-    char* malloc_test              = (char*)malloc(malloc_size);
-    snprintf(malloc_test, malloc_size, "ptr: %u, size:%d", malloc_size, (uintptr_t)malloc_test);
-    printf("%s", malloc_test);
 
     /* USER CODE END 1 */
 

--- a/projects/stm32l476_nucleo/blinky_picolibc/README.md
+++ b/projects/stm32l476_nucleo/blinky_picolibc/README.md
@@ -1,6 +1,10 @@
+## Description
+
+This is a **blinky** program, but we do not use **newlib** from GCC. Instead, we built **picolibc** from source and provided it (`elf.linkSystemLibrary("c_pico");`).
+Our Zig code begins at `zigEntrypoint`, and this function is called from C code using linker capabilities. The function is tagged with `callconv(.C)` to ensure compatibility with the C ABI.
+
 ## Use Zig after generating the project with STM32CubeMX
 
-Details about project structure are explained in this [chapter](#Structure).
 To use Zig in any microcontrollers `STM32CubeMX` generated project, with picolibc, follow these modification steps:
 
 1. **Create a `build.zig` file** and configure it to compile the C source files (Use this one as a model).

--- a/projects/stm32l476_nucleo/blinky_picolibc/README.md
+++ b/projects/stm32l476_nucleo/blinky_picolibc/README.md
@@ -18,7 +18,7 @@ To use Zig in any microcontrollers `STM32CubeMX` generated project, with picolib
     ```
 
 3. **Create the linker script** (`stm32l476rgtx_flash.ld`). This is a picolibc template that needs to be adjusted for your specific microcontrollers (e.g., RAM size, flash size, and additional sections).
-4. **Copy the `libc` folder** or generate the `libc` files. Refer to the [Picolibc Integration](#Picolibc-Integration) chapter for detailed instructions.
+4. **Copy the `libc` folder** or generate the `libc` files. Refer to the [Picolibc Integration](#Picolibc-Integration) chapter for detailed instructions. Warning: You need to rebuild the libc if the target parameters are different (e.g., float support, Cortex-M).
 5. **Create a `main.zig` file** with a custom entry point, such as `zigEntrypoint`.
 6. **Call the `zigEntrypoint` function** from the `main` function located in the `Core/Src/main.c` file.
 

--- a/projects/stm32l476_nucleo/blinky_picolibc/build.zig
+++ b/projects/stm32l476_nucleo/blinky_picolibc/build.zig
@@ -122,7 +122,7 @@ pub fn build(b: *std.Build) void {
         objsize.step.dependOn(&elf.step);
         b.default_step.dependOn(&objsize.step);
     } else {
-        std.log.warn("'size' program not found", .{});
+        std.log.warn("'llvm-size' or 'arm-none-eabi-size' program not found", .{});
     }
 
     // Copy the bin out of the elf

--- a/projects/stm32l476_nucleo/blinky_picolibc/build.zig
+++ b/projects/stm32l476_nucleo/blinky_picolibc/build.zig
@@ -111,6 +111,20 @@ pub fn build(b: *std.Build) void {
     elf.link_function_sections = true; // -ffunction-sections
     elf.link_gc_sections = true; // -Wl,--gc-sections
 
+    // Show section sizes inside binary files
+    const size_prog: ?[]const u8 = b.findProgram(&.{"arm-none-eabi-size"}, &.{}) catch
+        b.findProgram(&.{"llvm-size"}, &.{}) catch null;
+    if (size_prog) |name| {
+        const objsize = b.addSystemCommand(&[_][]const u8{
+            name,
+            "zig-out/bin/" ++ executable_name ++ ".elf",
+        });
+        objsize.step.dependOn(&elf.step);
+        b.default_step.dependOn(&objsize.step);
+    } else {
+        std.log.warn("'size' program not found", .{});
+    }
+
     // Copy the bin out of the elf
     const bin = b.addObjCopy(elf.getEmittedBin(), .{
         .format = .bin,

--- a/projects/stm32l476_nucleo/blinky_picolibc/src/main.zig
+++ b/projects/stm32l476_nucleo/blinky_picolibc/src/main.zig
@@ -12,7 +12,7 @@ const c = @cImport({
     @cInclude("main.h");
 });
 
-export fn zigEntrypoint() noreturn {
+export fn zigEntrypoint() callconv(.c) noreturn {
     while (true) {
         c.HAL_GPIO_WritePin(c.LD2_GPIO_Port, c.LD2_Pin, c.GPIO_PIN_RESET);
         c.HAL_Delay(200);

--- a/projects/stm32l476_nucleo/blinky_picolibc/src/main.zig
+++ b/projects/stm32l476_nucleo/blinky_picolibc/src/main.zig
@@ -10,6 +10,7 @@ const c = @cImport({
     @cDefine("STM32L476xx", {});
     @cDefine("__PROGRAM_START", {}); //bug: https://github.com/ziglang/zig/issues/22671
     @cInclude("main.h");
+    @cInclude("usart.h");
 });
 
 export fn zigEntrypoint() callconv(.c) noreturn {
@@ -19,4 +20,25 @@ export fn zigEntrypoint() callconv(.c) noreturn {
         c.HAL_GPIO_WritePin(c.LD2_GPIO_Port, c.LD2_Pin, c.GPIO_PIN_SET);
         c.HAL_Delay(500);
     }
+}
+
+// Custom debug Panic implementation that will be used to print on UART.
+pub const panic = std.debug.FullPanic(myPanic);
+
+fn myPanic(msg: []const u8, first_trace_addr: ?usize) noreturn {
+    // `_disable_irq()` is demoted to extern but don't work. Maybe because it is was a "static inline" function. Need investigation
+    asm volatile ("cpsid i" ::: "memory");
+
+    //Start printing, ensure error is impossible or ignore it. We are already on an error state.
+    var buffer: [1024]u8 = undefined;
+    var size: u16 = 0;
+    var result = std.fmt.bufPrint(&buffer, "\n\n", .{}) catch unreachable;
+    if (first_trace_addr) |addr| {
+        result = std.fmt.bufPrint(buffer[result.len..], "0x{x} / ", .{addr}) catch unreachable;
+        size += @intCast(result.len);
+    }
+    result = std.fmt.bufPrint(buffer[result.len..], "Panic! {s}\n", .{msg}) catch unreachable;
+    size += @intCast(result.len);
+    _ = c.HAL_UART_Transmit(&c.huart2, buffer[0..], size, 2000);
+    while (true) {}
 }


### PR DESCRIPTION
- Added `myPanic` function for each example
- Added `arm-none-eabi-size` or `llvm-size` command to be executed after build.
- Changed `zigEntrypoint` with `callconv(.c)` attribute
- Added Safe build task with Vscode
- Remove libc test Code in examples.
- Added description paragraph for each example